### PR TITLE
[WIP] Remove Sequence and Dict classes

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           channel-priority: strict
@@ -49,7 +48,6 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           channel-priority: strict

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
           use-mamba: true
           python-version: 3.9
           channel-priority: strict

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -60,7 +60,7 @@ jobs:
           mv test_report.html test_short_report.html deploy/
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        uses: JamesIves/github-pages-deploy-action@v4.6.8
         with:
           branch: gh-pages
           folder: deploy

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -28,7 +28,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           condarc-file: continuous_integration/condarc
           use-mamba: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           channel-priority: strict

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -54,7 +54,7 @@ jobs:
           regex: false
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         if: ${{ env.UCX_PY_VER != env.NEW_UCX_PY_VER }}  # make sure new ucx-py nightlies are available
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get latest cuDF nightly version
         id: cudf_latest
-        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.4
         with:
           org: "rapidsai-nightly"
           package: "cudf"
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get latest UCX-Py nightly version
         id: ucx_py_latest
-        uses: jacobtomlinson/gha-anaconda-package-version@0.1.3
+        uses: jacobtomlinson/gha-anaconda-package-version@0.1.4
         with:
           org: "rapidsai-nightly"
           package: "ucx-py"

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           channel-priority: strict

--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -9,6 +9,6 @@ LINUX_VER:
 - ubuntu20.04
 
 RAPIDS_VER:
-- "24.10"
+- "24.12"
 
 excludes:

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -1,0 +1,937 @@
+from __future__ import annotations
+
+""" Task specification for dask
+
+This module contains the task specification for dask. It is used to represent
+runnable and non-runnable (i.e. literals) tasks in a dask graph.
+
+Simple examples of how to express tasks in dask
+-----------------------------------------------
+
+.. code-block:: python
+
+    func("a", "b") ~ Task("key", func, "a", "b")
+
+    [func("a"), func("b")] ~ SequenceOfTasks(
+        "key",
+        [Task("key-1", func, "a"), Task("key-2", func, "b")]
+    )
+
+    {"a": func("b")} ~ DictOfTasks("key", {"a": Task("a", func, "b")})
+
+    "literal-string" ~ Literal("key", "literal-string")
+
+
+Keys, Aliases and TaskRefs
+-------------------------
+
+Keys are used to identify tasks in a dask graph. Every `GraphNode` instance has a
+key attribute that _should_ reference the key in the dask graph.
+
+.. code-block:: python
+
+    {"key": Task("key", func, "a")}
+
+Referencing other tasks is possible by using either one of `Alias` or a
+`TaskRef`.
+
+.. code-block:: python
+
+    # TaskRef can be used to provide the name of the reference explicitly
+    t = Task("key", func, TaskRef("key-1"))
+
+    # If a task is still in scope, the method `ref` can be used for convenience
+    t2 = Task("key2", func2, t.ref())
+
+Nested tasks and inlining
+-------------------------
+
+Tasks can be nested in a dict or list. This is useful for expressing more complex tasks.
+
+.. code-block:: python
+
+    func(func2("a", "b"), "c") ~ Task("key", func, [Task("key-1", func2, "a", "b"), "c"])
+
+    {"a": func("b")} ~ DictOfTasks("key", {"a": Task("a", func, "b")})
+
+This kind of nesting is often a byproduct of an optimizer step that inlines the
+tasks explicitly. This is done by calling the `inline` method on a task.
+
+.. code-block:: python
+
+    t1 = Task("key-1", func, "a")
+    t2 = Task("key-2", func, TaskRef("key-1"))
+
+    t2.inline({"key-1": t1}) ~ Task("key-2", func, Task("key-1", func, "a"))
+
+Executing a task
+----------------
+
+A task can be executed by calling it with a dictionary of values. The values
+should contain the dependencies of the task.
+
+.. code-block:: python
+
+    t = Task("key", add, TaskRef("a"), TaskRef("b"))
+    assert t.dependencies == {"a", "b"}
+    t({"a": 1, "b": 2}) == 3
+
+"""
+import itertools
+import sys
+from collections import defaultdict
+from collections.abc import Callable, Container, Iterable, Mapping, MutableMapping
+from contextlib import contextmanager
+from functools import partial
+from typing import TYPE_CHECKING, Any, overload
+
+from dask.base import tokenize
+from dask.core import reverse_dict
+from dask.sizeof import sizeof
+from dask.typing import Key as KeyType
+from dask.utils import is_namedtuple_instance
+
+try:
+    from distributed.collections import LRU
+except ImportError:
+
+    class LRU(dict):  # type: ignore[no-redef]
+        def __init__(self, *args, maxsize=None, **kwargs):
+            super().__init__(*args, **kwargs)
+
+
+if TYPE_CHECKING:
+    from typing import TypeVar
+
+    _T = TypeVar("_T", bound="GraphNode")
+
+
+def identity(*args):
+    return args
+
+
+_anom_count = itertools.count()
+
+
+@overload
+def parse_input(obj: dict) -> DictOfTasks | DataNode: ...
+
+
+@overload
+def parse_input(
+    obj: list | tuple | set | frozenset,
+) -> SequenceOfTasks | DataNode: ...
+
+
+@overload
+def parse_input(obj: TaskRef) -> Alias: ...
+
+
+@overload
+def parse_input(obj: _T) -> _T: ...
+
+
+def parse_input(obj: Any) -> GraphNode:
+    """Tokenize user input into GraphNode objects
+
+    Note: This is similar to `convert_old_style_task` but does not
+    - compare any values to a global set of known keys to infer references/futures
+    - parse tuples and interprets them as runnable tasks
+    - Deal with SubgraphCallables
+
+    Parameters
+    ----------
+    obj : _type_
+        _description_
+
+    Returns
+    -------
+    _type_
+        _description_
+    """
+    if isinstance(obj, GraphNode):
+        return obj
+    elif isinstance(obj, dict):
+        return DictOfTasks(None, obj).propagate_literal()
+    elif isinstance(obj, (list, tuple, set, frozenset)):
+        if is_namedtuple_instance(obj):
+            return _wrap_namedtuple_task(None, obj, parse_input)
+        return SequenceOfTasks(None, obj).propagate_literal()
+
+    if isinstance(obj, TaskRef):
+        return Alias(obj.key)
+
+    return obj
+
+
+def _wrap_namedtuple_task(k, obj, parser):
+    if hasattr(obj, "__getnewargs_ex__"):
+        new_args, kwargs = obj.__getnewargs_ex__()
+        kwargs = {k: parser(v) for k, v in kwargs.items()}
+    elif hasattr(obj, "__getnewargs__"):
+        new_args = obj.__getnewargs__()
+        kwargs = {}
+
+    args_converted = SequenceOfTasks(
+        None, map(parser, new_args), typ=type(new_args)
+    ).propagate_literal()
+
+    return Task(
+        k, partial(_instantiate_named_tuple, type(obj)), *args_converted, **kwargs
+    )
+
+
+def _instantiate_named_tuple(typ, *args, **kwargs):
+    return typ(*args, **kwargs)
+
+
+class _MultiSet(Container):
+    sets: tuple
+    __slots__ = ("sets",)
+
+    def __init__(self, *sets):
+        self.sets = sets
+
+    def __contains__(self, o: object) -> bool:
+        return any(o in s for s in self.sets)
+
+
+SubgraphType = None
+
+
+def convert_legacy_task(
+    k: KeyType | None,
+    arg: Any,
+    all_keys: Container,
+    only_refs: bool,
+    cache: MutableMapping,
+) -> GraphNode:
+    global SubgraphType
+    if SubgraphType is None:
+        from dask.optimization import SubgraphCallable
+
+        SubgraphType = SubgraphCallable
+
+    if isinstance(arg, GraphNode):
+        return arg
+    rv: GraphNode
+    inner = partial(convert_legacy_task, None, only_refs=only_refs, cache=cache)
+
+    inner_args = partial(inner, all_keys=all_keys)
+    if type(arg) is tuple and arg and callable(arg[0]):
+        if k is None:
+            k = ("anom", next(_anom_count))
+
+        func, args = arg[0], arg[1:]
+        if isinstance(func, SubgraphType):
+            # FIXME: This parsing is inlining tasks of the subgraph, i.e. it can
+            # multiply work if the subgraph has keys that are reused in the
+            # subgraph
+            subgraph = func
+            all_keys_inner = _MultiSet(all_keys, set(subgraph.inkeys), subgraph.dsk)
+            if subgraph.name in cache:
+                func = cache[subgraph.name]
+            else:
+                sub_dsk = convert_legacy_graph(
+                    subgraph.dsk, all_keys_inner, only_refs, cache
+                )
+                cache[subgraph.name] = func = sub_dsk[subgraph.outkey].inline(sub_dsk)
+                del sub_dsk
+
+            new_args_l = map(partial(inner, all_keys=all_keys_inner), args)
+
+            func2 = func.inline(dict(zip(subgraph.inkeys, new_args_l)))
+            dct = {k: Alias(k) for k in func2.dependencies}
+            return Task(k, func2, dct)
+        else:
+            new_args = map(inner_args, args)
+            if only_refs:
+                # this can't be a literal since the literal wouldn't execute
+                # new_args in case there were runnable tasks or other literals
+                # See test_convert_task_only_ref
+                return Task(k, identity, func, *new_args)
+            return Task(k, func, *new_args)
+    try:
+        if isinstance(arg, (bytes, int, float, str, tuple)) and arg in all_keys:
+            if arg in cache:
+                return cache[arg]
+            cache[arg] = rv = Alias(arg)
+            return rv
+    except TypeError:
+        # Unhashable
+        pass
+
+    if isinstance(arg, (list, tuple, set, frozenset)):
+        if is_namedtuple_instance(arg):
+            rv = _wrap_namedtuple_task(k, arg, inner_args)
+        else:
+            rv = SequenceOfTasks(k, map(inner_args, arg), typ=type(arg))
+        return rv.propagate_literal()
+    elif isinstance(arg, dict):
+        new_dsk = convert_legacy_graph(
+            arg, all_keys=all_keys, only_refs=True, cache=cache
+        )
+
+        return DictOfTasks(None, new_dsk).propagate_literal()
+
+    elif isinstance(arg, TaskRef):
+        return Alias(arg.key)
+    else:
+        return arg
+
+
+def convert_legacy_graph(
+    dsk: Mapping,
+    all_keys: Container | None = None,
+    only_refs: bool = False,
+    cache: MutableMapping | None = None,
+):
+    if not all_keys:
+        all_keys = set(dsk)
+    new_dsk = {}
+    if cache is None:
+        cache = {}
+    for k, arg in dsk.items():
+        t = convert_legacy_task(k, arg, all_keys, only_refs, cache=cache)
+        if not only_refs and isinstance(t, Alias) and t.key == k:
+            continue
+        new_dsk[k] = t
+    new_dsk2 = {
+        k: v if isinstance(v, GraphNode) else DataNode(k, v) for k, v in new_dsk.items()
+    }
+    return new_dsk2
+
+
+def resolve_aliases(dsk: dict, keys: set, dependents: dict) -> dict:
+    """Remove trivial sequential alias chains
+
+    Example:
+
+        dsk = {'x': 1, 'y': Alias('x'), 'z': Alias('y')}
+
+        resolve_aliases(dsk, {'z'}, {'x': {'y'}, 'y': {'z'}}) == {'z': 1}
+
+    """
+    if not keys:
+        raise ValueError("No keys provided")
+    dsk = dict(dsk)
+    work = list(keys)
+    seen = set()
+    while work:
+        k = work.pop()
+        if k in seen or k not in dsk:
+            continue
+        seen.add(k)
+        t = dsk[k]
+        if isinstance(t, Alias):
+            target_key = t.target.key
+            # Rules for when we allow to collapse an alias
+            # 1. The target key is not in the keys set. The keys set is what the
+            #    user is requesting and by collapsing we'd no longer be able to
+            #    return that result.
+            # 2. The target key is in fact part of dsk. If it isnt' this could
+            #    point to a persisted dependency and we cannot collapse it.
+            # 3. The target key has only one dependent which is the key we're
+            #    currently looking at. This means that there is a one to one
+            #    relation between this and the target key in which case we can
+            #    collapse them.
+            #    Note: If target was an alias as well, we could continue with
+            #    more advanced optimizations but this isn't implemented, yet
+            if (
+                target_key not in keys
+                and target_key in dsk
+                # Note: whenever we're performing a collapse, we're not updating
+                # the dependents. The length == 1 should still be sufficient for
+                # chains of these aliases
+                and len(dependents[target_key]) == 1
+            ):
+                tnew = dsk.pop(target_key).copy()
+
+                dsk[k] = tnew
+                tnew.key = k
+                if isinstance(tnew, Alias):
+                    work.append(k)
+                    seen.discard(k)
+
+        work.extend(t.dependencies)
+    return dsk
+
+
+class TaskRef:
+    val: KeyType
+    __slots__ = ("key",)
+
+    def __init__(self, key: KeyType):
+        self.key = key
+
+    def __str__(self):
+        return str(self.key)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self.key!r})"
+
+    def __hash__(self) -> int:
+        return hash(self.key)
+
+
+_func_cache: MutableMapping = LRU(maxsize=1000)
+_func_cache_reverse: MutableMapping = LRU(maxsize=1000)
+
+
+class GraphNode:
+    key: KeyType
+    dependencies: set | frozenset | tuple
+
+    __slots__ = tuple(__annotations__)
+
+    def ref(self):
+        return Alias(self.key)
+
+    def copy(self):
+        raise NotImplementedError
+
+    def _verify_values(self, values: tuple | dict) -> None:
+        if not self.dependencies:
+            return
+        if missing := set(self.dependencies) - set(values):
+            raise RuntimeError(f"Not enough arguments provided: missing keys {missing}")
+
+    def inline(self, dsk) -> GraphNode:
+        raise NotImplementedError("Not implemented")
+
+    def propagate_literal(self) -> GraphNode:
+        """Return a literal if all tasks are literals"""
+        return self
+
+    def __call__(self, values) -> Any:
+        raise NotImplementedError("Not implemented")
+
+    @property
+    def is_coro(self) -> bool:
+        return False
+
+    def __sizeof__(self) -> int:
+        return sys.getsizeof(type(self)) + sizeof(self.key) + sizeof(self.dependencies)
+
+
+_no_deps: set = set()
+
+
+class Alias(GraphNode):
+    __weakref__: Any = None
+    _dependencies: set | None
+    target: TaskRef
+    __slots__ = tuple(__annotations__)
+
+    def __init__(self, key: KeyType, target: Alias | TaskRef | KeyType | None = None):
+        self.key = key
+        if target is None:
+            target = key
+        if isinstance(target, Alias):
+            target = target.target
+        if not isinstance(target, TaskRef):
+            target = TaskRef(target)
+        self.target = target
+        self._dependencies = None
+
+    @property
+    def dependencies(self):
+        if self._dependencies is None:
+            self._dependencies = {self.target.key}
+        return self._dependencies
+
+    def copy(self):
+        return Alias(self.key, self.target)
+
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        return Alias, (self.key, self.target)
+
+    def __call__(self, values=()):
+        self._verify_values(values)
+        return values[self.target.key]
+
+    def inline(self, dsk) -> GraphNode:
+        if self.key in dsk:
+            # This can otherwise cause recursion errors
+            new_dsk = dsk.copy()
+            new_dsk.pop(self.key)
+            if isinstance(dsk[self.key], GraphNode):
+                return dsk[self.key].inline(new_dsk)
+            else:
+                return dsk[self.key]
+        else:
+            return self
+
+    def __repr__(self):
+        return f"Alias(key={self.key}, target={self.target})"
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, Alias):
+            return False
+        if self.key != value.key:
+            return False
+        if self.key != value.key:
+            return False
+        return True
+
+
+class DataNode(GraphNode):
+    value: Any
+    typ: type
+    __slots__ = tuple(__annotations__)
+
+    def __init__(self, key: Any, value: Any):
+        if key is None:
+            key = (type(value).__name__, next(_anom_count))
+        self.key = key
+        self.value = value
+        self.typ = type(value)
+        self.dependencies = _no_deps
+
+    def inline(self, dsk) -> DataNode:
+        return self
+
+    def copy(self):
+        return DataNode(self.key, self.value)
+
+    def __call__(self, values=()):
+        return self.value
+
+    def __repr__(self):
+        return f"Literal({self.key}, type={self.typ}, {self.value})"
+
+    def __dask_tokenize__(self):
+        return (type(self).__name__, tokenize(self.value))
+
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        return DataNode, (self.key, self.value)
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, DataNode):
+            return False
+        if self.value != value.value:
+            return False
+        return True
+
+    def __sizeof__(self) -> int:
+        return super().__sizeof__() + sizeof(self.value) + sizeof(self.typ)
+
+    def __iter__(self):
+        return iter(self.value)
+
+
+class Task(GraphNode):
+    func: Callable | None
+    args: SequenceOfTasks | DataNode
+    kwargs: DictOfTasks | DataNode
+    packed_func: None | bytes
+    _token: tuple | None
+    _is_coro: bool | None
+
+    __slots__ = tuple(__annotations__)
+
+    def __init__(
+        self,
+        key: Any,
+        func: Callable,
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ):
+        self.key = key
+        self.func = func
+        self.packed_func = None
+        dependencies: set = set()
+        self.args = parse_input(args)
+        dependencies.update(self.args.dependencies)
+        self.kwargs = parse_input(kwargs)
+        dependencies.update(self.kwargs.dependencies)
+        if dependencies:
+            self.dependencies = dependencies
+        else:
+            self.dependencies = _no_deps
+        self._is_coro = None
+        self._token = None
+
+    def copy(self):
+        self.unpack()
+        kwargs = self.kwargs.value if isinstance(self.kwargs, DataNode) else self.kwargs
+        return Task(self.key, self.func, *self.args, **kwargs)
+
+    def __hash__(self):
+        return hash(self._get_token())
+
+    def is_packed(self):
+        return self.packed_func is not None
+
+    def _get_token(self):
+        if self._token:
+            return self._token
+        self.unpack()
+        from dask.base import tokenize
+
+        self._token = tokenize(
+            (
+                type(self).__name__,
+                self.func,
+                self.args,
+                self.kwargs,
+            )
+        )
+        return self._token
+
+    def __dask_tokenize__(self):
+        return self._get_token()
+
+    def __sizeof__(self) -> int:
+        return (
+            super().__sizeof__()
+            + sizeof(self.func or self.packed_func)
+            + sizeof(self.args)
+            + sizeof(self.kwargs)
+        )
+
+    def __repr__(self) -> str:
+        return f"Task({self.key!r})"
+
+    def __call__(self, values=()):
+        self._verify_values(values)
+        try:
+            self.unpack()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Exception occured during deserialization of function for task {self.key}"
+            ) from exc
+        assert self.func is not None
+        new_argspec = self.args(values)
+        if self.kwargs:
+            kwargs = self.kwargs(values)
+            return self.func(*new_argspec, **kwargs)
+        return self.func(*new_argspec)
+
+    def pack(self):
+        # TODO: pack args and kwargs as well. Probably with a sizeof threshold
+        if self.is_packed():
+            return self
+        try:
+            from distributed.protocol.pickle import dumps
+        except ImportError:
+            from cloudpickle import dumps
+
+        try:
+            self.packed_func = _func_cache[self.func]
+            self.func = None
+            return self
+        except (KeyError, TypeError):
+            # We're not handling the below in this except to simplify traceback
+            # and cause
+            pass
+        try:
+            self.packed_func = dumps(self.func)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Error during serialization of function of task {self.key}"
+            ) from exc
+        try:
+            _func_cache_reverse[self.packed_func], _func_cache[self.func] = (
+                self.func,
+                self.packed_func,
+            )
+        except TypeError:
+            pass
+        self.func = None
+        return self
+
+    def lazy_pack(self):
+        # TODO: This could dispatch to a TPE and de/serialize the arguments
+        # lazily such that pack only waits for the result. This way we can use
+        # spare CPU cycles and parallelize on multiple CPUs.
+        # Thread safety should not be an issue if we guarantee idempotency and
+        # that the non-lazy sync also uses this
+        # This may block the GIL pretty aggressively
+        raise NotImplementedError("Not implemented")
+
+    def lazy_unpack(self):
+        raise NotImplementedError("Not implemented")
+
+    def inline(self, dsk) -> Task:
+        self.unpack()
+        new_args = self.args.inline(dsk)
+        new_kwargs = self.kwargs.inline(dsk)
+        if isinstance(new_kwargs, DataNode):
+            kwargs = new_kwargs.value
+        else:
+            kwargs = new_kwargs.tasks
+        assert self.func is not None
+        return Task(self.key, self.func, *new_args, **kwargs)
+
+    def unpack(self):
+        if not self.is_packed():
+            return
+        assert self.packed_func is not None
+
+        try:
+            from distributed.protocol.pickle import loads
+        except ImportError:
+            from cloudpickle import loads
+        try:
+            self.func = _func_cache_reverse[self.packed_func]
+            self.packed_func = None
+            return self
+        except KeyError:
+            # We're not handling the below in this except to simplify traceback
+            # and cause
+            pass
+        try:
+            self.func = loads(self.packed_func)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Error during deserialization of function of task {self.key}"
+            ) from exc
+        try:
+            _func_cache_reverse[self.packed_func], _func_cache[self.func] = (
+                self.func,
+                self.packed_func,
+            )
+        except TypeError:
+            pass
+        self.packed_func = None
+        return self
+
+    def __getstate__(self):
+        self.pack()
+        return {
+            "key": self.key,
+            "packed_func": self.packed_func,
+            "dependencies": self.dependencies,
+            "kwargs": self.kwargs,
+            "args": self.args,
+            "_is_coro": self._is_coro,
+            "_token": self._token,
+        }
+
+    def __setstate__(self, state):
+        self.key = state["key"]
+        self.packed_func = state["packed_func"]
+        self.dependencies = state["dependencies"]
+        self.kwargs = state["kwargs"]
+        self.args = state["args"]
+        self._is_coro = state["_is_coro"]
+        self._token = state["_token"]
+        self.func = None
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, Task):
+            return False
+        if self.key != value.key:
+            return False
+        if self.packed_func != value.packed_func:
+            return False
+        if self.func != value.func:
+            return False
+        if self.dependencies != value.dependencies:
+            return False
+        if self.kwargs != value.kwargs:
+            return False
+        if self.args != value.args:
+            return False
+        return True
+
+    @property
+    def is_coro(self):
+        if self._is_coro is None:
+            self.unpack()
+            # Note: Can't use cached_property on objects without __dict__
+            try:
+                from distributed.utils import iscoroutinefunction
+
+                self._is_coro = iscoroutinefunction(self.func)
+            except Exception:
+                self._is_coro = False
+        return self._is_coro
+
+
+class DictOfTasks(GraphNode):
+    tasks: dict
+    __slots__ = tuple(__annotations__)
+
+    def __init__(self, key: Any, nested_tasks: dict):
+        self.key = key
+        self.dependencies = set()
+        self.tasks = {}
+        for k, task in nested_tasks.items():
+            self.tasks[k] = task = parse_input(task)
+            if isinstance(task, GraphNode):
+                self.dependencies.update(task.dependencies)
+
+    def inline(self, dsk) -> DictOfTasks:
+        new_tasks = {k: task.inline(dsk) for k, task in self.tasks.items()}
+        return DictOfTasks(self.key, new_tasks)
+
+    def __iter__(self):
+        return iter(self.tasks)
+
+    def __call__(self, values=()) -> dict:
+        self._verify_values(values)
+        return {
+            k: task(values) if isinstance(task, GraphNode) else task
+            for k, task in self.tasks.items()
+        }
+
+    def copy(self):
+        return DictOfTasks(self.key, self.tasks)
+
+    def propagate_literal(self) -> GraphNode:
+        """Return a literal if all tasks are literals"""
+        if any(
+            isinstance(t, GraphNode) and not isinstance(t, DataNode)
+            for t in self.tasks.values()
+        ):
+            return self
+        return DataNode(self.key, self())
+
+    def __sizeof__(self):
+        return super().__sizeof__() + sizeof(self.tasks)
+
+
+class SequenceOfTasks(GraphNode):
+    typ: type
+    _isnamed_tuple: bool
+    tasks: list | tuple
+    _constructor_kwargs: dict
+
+    __slots__ = tuple(__annotations__)
+
+    def __init__(
+        self,
+        key: Any,
+        nested_tasks: list | tuple | Iterable,
+        typ: type | None = None,
+    ):
+        self.key = key
+        self.dependencies = set()
+        self.tasks = []
+        self.typ = typ or type(nested_tasks)
+        for task in nested_tasks:
+            task = parse_input(task)
+            self.tasks.append(task)
+            if isinstance(task, GraphNode):
+                self.dependencies.update(task.dependencies)
+
+    def __iter__(self):
+        return iter(self.tasks)
+
+    def copy(self):
+        return SequenceOfTasks(self.key, self.tasks, self.typ)
+
+    def inline(self, dsk: dict) -> SequenceOfTasks | DataNode:
+        new_tasks = []
+        all_literals = True
+        for task in self.tasks:
+            if not isinstance(task, GraphNode):
+                new_tasks.append(task)
+                continue
+            new_tasks.append(inner := task.inline(dsk))
+            if all_literals and not isinstance(inner, DataNode):
+                all_literals = False
+        rv = SequenceOfTasks(self.key, new_tasks)
+        if all_literals:
+            return DataNode(self.key, rv())
+        return rv
+
+    def __dask_tokenize__(self):
+        return (type(self).__name__, tokenize(self.tasks))
+
+    def __call__(self, values=()) -> list | tuple:
+        self._verify_values(values)
+        return self.typ(
+            task(values) if isinstance(task, GraphNode) else task for task in self.tasks
+        )
+
+    def propagate_literal(self):
+        """Return a literal if all tasks are literals"""
+        if any(
+            isinstance(t, GraphNode) and not isinstance(t, DataNode) for t in self.tasks
+        ):
+            return self
+        return DataNode(self.key, self())
+
+    def __sizeof__(self):
+        return super().__sizeof__() + sizeof(self.tasks) + sizeof(self.typ)
+
+
+class DependenciesMapping(Mapping):
+    def __init__(self, dsk):
+        self.dsk = dsk
+        self.blocklist = None
+        self.removed_keys = set()
+
+    def __getitem__(self, key):
+        if key in self.removed_keys:
+            raise KeyError(key)
+        v = self.dsk[key]
+        if not isinstance(v, GraphNode):
+            from dask.core import get_dependencies
+
+            return get_dependencies(self.dsk, task=self.dsk[key])
+        if self.blocklist and self.blocklist[key]:
+            return self.dsk[key].dependencies - self.blocklist[key]
+        return self.dsk[key].dependencies
+
+    def __iter__(self):
+        return iter(self.dsk)
+
+    def copy(self):
+        return DependenciesMapping(self.dsk)
+
+    def __delitem__(self, key):
+        self.removed_keys.add(key)
+
+    def remove_dependency(self, key, dep):
+        if self.blocklist is None:
+            self.blocklist = defaultdict(set)
+        self.blocklist[key].add(dep)
+
+    def __len__(self) -> int:
+        return len(self.dsk)
+
+
+def get_deps(dsk):
+    # FIXME: I think we don't need this function
+    assert all(isinstance(v, GraphNode) for v in dsk.values())
+    dependencies = DependenciesMapping(dsk)
+    dependents = reverse_dict(dependencies)
+    return dependencies, dependents
+
+
+class _DevNullMapping(MutableMapping):
+    def __getitem__(self, key):
+        raise KeyError(key)
+
+    def __setitem__(self, key, value):
+        pass
+
+    def __delitem__(self, key):
+        pass
+
+    def __len__(self):
+        return 0
+
+    def __iter__(self):
+        return iter(())
+
+
+@contextmanager
+def no_function_cache():
+    """Everything in this context will ignore the function cache on both
+    serialization and deserialization.
+
+    This is not threadsafe!
+    """
+    global _func_cache, _func_cache_reverse
+    cache_before = _func_cache, _func_cache_reverse
+    _func_cache, _func_cache_reverse = _DevNullMapping(), _DevNullMapping()
+    try:
+        yield
+    finally:
+        _func_cache, _func_cache_reverse = cache_before

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3635,9 +3635,9 @@ def from_zarr(
             store = zarr.storage.FSStore(url, **storage_options)
         else:
             store = url
-        z = zarr.Array(store, read_only=True, path=component, **kwargs)
+        z = zarr.open_array(store, read_only=True, path=component, **kwargs)
     else:
-        z = zarr.Array(url, read_only=True, path=component, **kwargs)
+        z = zarr.open_array(url, read_only=True, path=component, **kwargs)
     chunks = chunks if chunks is not None else z.chunks
     if name is None:
         name = "from-zarr-" + tokenize(z, component, storage_options, chunks, **kwargs)

--- a/dask/core.py
+++ b/dask/core.py
@@ -43,6 +43,12 @@ def istask(x):
     >>> istask(1)
     False
     """
+    from dask._task_spec import DataNode, GraphNode
+
+    if isinstance(x, GraphNode):
+        if isinstance(x, DataNode):
+            return False
+        return True
     return type(x) is tuple and x and callable(x[0])
 
 
@@ -178,7 +184,9 @@ def keys_in_tasks(keys: Collection[Key], tasks: Iterable[Any], as_list: bool = F
     >>> keys_in_tasks(dsk, ['x', 'y', 'j'])  # doctest: +SKIP
     {'x', 'y'}
     """
-    ret = []
+    from dask._task_spec import GraphNode
+
+    ret: list[Key] = []
     while tasks:
         work = []
         for w in tasks:
@@ -189,6 +197,8 @@ def keys_in_tasks(keys: Collection[Key], tasks: Iterable[Any], as_list: bool = F
                 work.extend(w)
             elif typ is dict:
                 work.extend(w.values())
+            elif isinstance(w, GraphNode):
+                ret.extend(w.dependencies)
             else:
                 try:
                     if w in keys:

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -463,7 +463,12 @@ def test_check_matching_columns_raises_appropriate_errors():
     df = pd.DataFrame(columns=["a", "b", "c"])
 
     meta = pd.DataFrame(columns=["b", "a", "c"])
-    with pytest.raises(ValueError, match="Order of columns does not match"):
+    with pytest.raises(
+        ValueError,
+        match="Order of columns does not match."
+        "\nActual:   \\['a', 'b', 'c'\\]"
+        "\nExpected: \\['b', 'a', 'c'\\]",
+    ):
         assert check_matching_columns(meta, df)
 
     meta = pd.DataFrame(columns=["a", "b", "c", "d"])

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -434,10 +434,14 @@ def check_matching_columns(meta, actual):
         if extra or missing:
             extra_info = f"  Extra:   {extra}\n  Missing: {missing}"
         else:
-            extra_info = "Order of columns does not match"
+            extra_info = (
+                f"Order of columns does not match."
+                f"\nActual:   {actual.columns.tolist()}"
+                f"\nExpected: {meta.columns.tolist()}"
+            )
         raise ValueError(
             "The columns in the computed data do not match"
-            " the columns in the provided metadata\n"
+            " the columns in the provided metadata.\n"
             f"{extra_info}"
         )
 

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -1,0 +1,691 @@
+from __future__ import annotations
+
+import pickle
+import sys
+from collections import namedtuple
+
+import pytest
+
+import dask
+from dask._task_spec import (
+    Alias,
+    DataNode,
+    DependenciesMapping,
+    DictOfTasks,
+    SequenceOfTasks,
+    Task,
+    TaskRef,
+    convert_legacy_graph,
+    no_function_cache,
+    resolve_aliases,
+)
+from dask.base import tokenize
+from dask.core import reverse_dict
+from dask.optimization import SubgraphCallable
+from dask.sizeof import sizeof
+
+
+@pytest.fixture(autouse=True)
+def clear_func_cache():
+    from dask._task_spec import _func_cache, _func_cache_reverse
+
+    _func_cache.clear()
+    _func_cache_reverse.clear()
+
+
+def func(*args):
+    try:
+        return "-".join(args)
+    except TypeError:
+        return "-".join(map(str, args))
+
+
+def func2(*args):
+    return "=".join(args)
+
+
+def func3(*args, **kwargs):
+    return "+".join(args) + "//" + "+".join(f"{k}={v}" for k, v in kwargs.items())
+
+
+def test_convert_legacy_dsk_skip_new():
+    dsk = {
+        "key-1": Task("key-1", func, "a", "b"),
+    }
+    converted = convert_legacy_graph(dsk)
+    assert converted["key-1"] is dsk["key-1"]
+    assert converted == dsk
+
+
+def _assert_dsk_conversion(new_dsk):
+    vals = [(k, v.key) for k, v in new_dsk.items()]
+    assert all(v[0] == v[1] for v in vals), vals
+
+
+def test_convert_legacy_dsk():
+    def func(*args):
+        return "-".join(args)
+
+    def func2(*args):
+        return "=".join(args)
+
+    dsk = {
+        "key-1": (func, "a", "b"),
+        "key-2": (func2, "key-1", "c"),
+        "key-3": (func, (func2, "c", "key-1"), "key-2"),
+        "const": "foo",
+        "key-4": [
+            (func, "key-1", "b"),
+            (func, "c", "key-2"),
+            (func, "key-3", "f"),
+            (func, "const", "bar"),
+        ],
+    }
+    new_dsk = convert_legacy_graph(dsk)
+    _assert_dsk_conversion(new_dsk)
+    t1 = new_dsk["key-1"]
+    assert isinstance(t1, Task)
+    assert t1.func == func
+    v1 = t1()
+    assert v1 == func("a", "b")
+
+    t2 = new_dsk["key-2"]
+    assert isinstance(t2, Task)
+    v2 = t2({"key-1": v1})
+    assert v2 == func2(func("a", "b"), "c")
+
+    t3 = new_dsk["key-3"]
+    assert isinstance(t3, Task)
+    assert len(t3.dependencies) == 2
+    v3 = t3({"key-1": v1, "key-2": v2})
+    assert v3 == func(func2("c", func("a", "b")), func2(func("a", "b"), "c"))
+    t4 = new_dsk["key-4"]
+    assert isinstance(t4, SequenceOfTasks)
+    assert t4.dependencies == {"key-1", "key-2", "key-3", "const"}
+    assert t4(
+        {
+            "key-1": v1,
+            "key-2": v2,
+            "key-3": v3,
+            "const": "foo",
+        }
+    ) == [
+        func(v1, "b"),
+        func("c", v2),
+        func(v3, "f"),
+        func("foo", "bar"),
+    ]
+
+
+def test_task_executable():
+    t1 = Task("key-1", func, "a", "b")
+    assert t1() == func("a", "b")
+
+
+def test_reference_remote():
+    t1 = Task("key-1", func, "a", "b")
+    t2 = Task("key-2", func2, TaskRef("key-1"), "c")
+    with pytest.raises(RuntimeError):
+        t2()
+    assert t2({"key-1": t1()}) == func2(func("a", "b"), "c")
+
+
+def test_reference_remote_twice_same():
+    t1 = Task("key-1", func, "a", "b")
+    t2 = Task("key-2", func2, TaskRef("key-1"), TaskRef("key-1"))
+    with pytest.raises(RuntimeError):
+        t2()
+    assert t2({"key-1": t1()}) == func2(func("a", "b"), func("a", "b"))
+
+
+def test_reference_remote_twice_different():
+    t1 = Task("key-1", func, "a", "b")
+    t2 = Task("key-2", func, "c", "d")
+    t3 = Task("key-3", func2, TaskRef("key-1"), TaskRef("key-2"))
+    with pytest.raises(RuntimeError):
+        t3()
+    assert t3({"key-1": t1(), "key-2": t2()}) == func2(func("a", "b"), func("c", "d"))
+
+
+def test_task_nested():
+    t1 = Task("key-1", func, "a", "b")
+    t2 = Task("key-2", func2, t1, "c")
+    assert t2() == func2(func("a", "b"), "c")
+
+
+class SerializeOnlyOnce:
+    deserialized = False
+    serialized = False
+
+    def __getstate__(self):
+        if SerializeOnlyOnce.serialized:
+            raise RuntimeError()
+        SerializeOnlyOnce.serialized = True
+        return {}
+
+    def __setstate__(self, state):
+        if SerializeOnlyOnce.deserialized:
+            raise RuntimeError()
+        SerializeOnlyOnce.deserialized = True
+
+    def __call__(self, a, b):
+        return a + b
+
+
+def test_pickle():
+    f = SerializeOnlyOnce()
+
+    t1 = Task("key-1", f, "a", "b")
+    t2 = Task("key-2", f, "c", "d")
+
+    rtt1 = pickle.loads(pickle.dumps(t1))
+    rtt2 = pickle.loads(pickle.dumps(t2))
+    # packing is inplace. Not strictly necessary, but this way we avoid creating
+    # another py object
+    assert t1.is_packed()
+    assert t2.is_packed()
+    assert rtt1.is_packed()
+    assert rtt2.is_packed()
+    assert t1 == rtt1
+    assert t1.func == rtt1.func
+    assert t1.func is rtt1.func
+    assert t1.func is rtt2.func
+
+
+def test_tokenize():
+    t = Task("key-1", func, "a", "b")
+    assert tokenize(t) == tokenize(t)
+
+    t2 = Task("key-1", func, "a", "b")
+    assert tokenize(t) == tokenize(t2)
+
+    token_before = tokenize(t)
+    t.pack()
+    assert t.is_packed()
+    assert not t2.is_packed()
+    assert token_before == tokenize(t) == tokenize(t2)
+
+    # Literals are often generated with random/anom names but that should not
+    # impact hashing. Otherwise identical submits would end up with different
+    # tokens
+    l = DataNode("key-1", "a")
+    l2 = DataNode("key-2", "a")
+    assert tokenize(l) == tokenize(l2)
+
+
+def test_async_func():
+    pytest.importorskip("distributed")
+    from distributed.utils_test import gen_test
+
+    @gen_test()
+    async def _():
+        async def func(a, b):
+            return a + b
+
+        t = Task("key-1", func, "a", "b")
+        assert t.is_coro
+        t.pack()
+        assert t.is_coro
+        t.unpack()
+        assert await t() == "ab"
+        assert await pickle.loads(pickle.dumps(t))() == "ab"
+
+        # Ensure that if the property is only accessed after packing, it is
+        # still correct
+        t = Task("key-1", func, "a", "b")
+        t.pack()
+        assert t.is_coro
+
+    _()
+
+
+def test_parse_curry():
+    def curry(func, *args, **kwargs):
+        return func(*args, **kwargs) + "c"
+
+    dsk = {
+        "key-1": (curry, func, "a", "b"),
+    }
+    converted = convert_legacy_graph(dsk)
+    _assert_dsk_conversion(converted)
+    t = Task("key-1", curry, func, "a", "b")
+    assert converted["key-1"]() == t()
+    assert t() == "a-bc"
+
+
+def test_curry():
+    def curry(func, *args, **kwargs):
+        return func(*args, **kwargs) + "c"
+
+    t = Task("key-1", curry, func, "a", "b")
+    assert t() == "a-bc"
+
+
+def test_avoid_cycles():
+    pytest.importorskip("distributed")
+    from dask._task_spec import TaskRef
+
+    dsk = {
+        "key": TaskRef("key"),  # e.g. a persisted key
+    }
+    new_dsk = convert_legacy_graph(dsk)
+    assert not new_dsk
+
+
+def test_convert_task_only_ref():
+    # This is for support of legacy subgraphs
+    # We'll only want to insert pack/unpack dependencies but don't want to touch
+    # the task itself
+
+    def subgraph_func(dsk, key):
+        return dask.get(dsk, [key])[0]
+
+    dsk = {
+        "dep": "foo",
+        ("baz", 1): "baz",
+        "subgraph": (
+            subgraph_func,
+            {
+                "a": "dep",
+                "b": (func, "a", "bar"),
+                "c": (func, "a", ("baz", 1)),
+                "d": (func, "b", "c"),
+            },
+            "d",
+        ),
+    }
+    new_dsk = convert_legacy_graph(dsk)
+    _assert_dsk_conversion(new_dsk)
+    assert new_dsk["subgraph"].dependencies == {"dep", ("baz", 1)}
+
+    assert new_dsk["subgraph"]({"dep": "foo", ("baz", 1): "baz"}) == "foo-bar-foo-baz"
+
+
+def test_runnable_as_kwarg():
+    def func_kwarg(a, b, c=""):
+        return a + b + str(c)
+
+    t = Task(
+        "key-1",
+        func_kwarg,
+        "a",
+        "b",
+        c=Task("key-2", sum, [1, 2]),
+    )
+    assert t() == "ab3"
+
+
+def test_subgraph_callable():
+    def add(a, b):
+        return a + b
+
+    subgraph = SubgraphCallable(
+        {
+            "_2": (add, "_0", "_1"),
+            "_3": (add, TaskRef("add-123"), "_2"),
+        },
+        "_3",
+        ("_0", "_1"),
+    )
+
+    dsk = {
+        "a": 1,
+        "b": 2,
+        "c": (subgraph, "a", "b"),
+    }
+    new_dsk = convert_legacy_graph(dsk)
+    _assert_dsk_conversion(new_dsk)
+    assert new_dsk["c"].dependencies == {"a", "b", "add-123"}
+    assert (
+        new_dsk["c"](
+            {
+                "add-123": 123,
+                "a": 1,
+                "b": 2,
+            }
+        )
+        == 126
+    )
+
+
+def apply(func, args, kwargs=None):
+    return func(*args, **(kwargs or {}))
+
+
+def test_redirect_to_subgraph_callable():
+    subgraph = SubgraphCallable(
+        {
+            "out": (apply, func3, ["_0"], (dict, [["some", "dict"]])),
+        },
+        "out",
+        ("_0",),
+    )
+    dsk = {
+        "alias": "foo",
+        "foo": (func, (subgraph, (func2, "bar", "baz")), "second_arg"),
+    }
+    new_dsk = convert_legacy_graph(dsk)
+    from dask import get
+
+    expected = get(dsk, ["foo"])[0]
+    assert expected == "bar=baz//some=dict-second_arg"
+    t = new_dsk["alias"]
+    assert t.dependencies == {"foo"}
+    t = new_dsk["foo"]
+    assert not t.dependencies
+
+    assert t() == expected
+
+
+def test_inline():
+    t = Task("key-1", func, "a", TaskRef("b"))
+
+    assert t.inline({"b": DataNode(None, "b")})() == "a-b"
+
+    assert t.inline({"b": Task(None, func, "b", "c")})() == "a-b-c"
+
+    t2 = Task("key-1", func, TaskRef("a"), TaskRef("b"))
+    inline2 = t2.inline({"a": DataNode(None, "a")})
+    assert inline2.dependencies == {"b"}
+
+    assert inline2({"b": "foo"}) == "a-foo"
+
+    t = SequenceOfTasks("key-1", [t, t2])
+    assert t.dependencies == {"b", "a"}
+    inlined = t.inline({"a": DataNode(None, "foo")})
+    assert inlined.dependencies == {"b"}
+    assert inlined({"b": "bar"}) == ["a-bar", "foo-bar"]
+
+    t = SequenceOfTasks("key-2", [t, t2])
+    t = DictOfTasks("key-2", {"foo": t, "bar": t2})
+    inlined = t.inline(
+        {
+            "a": DataNode(None, "foo"),
+            "bar": DataNode(None, "bar"),
+        }
+    )
+    assert inlined({"b": "bar"})
+
+    t = SequenceOfTasks("key-1", [TaskRef("a"), TaskRef("b")])
+    inlined = t.inline({"a": DataNode(None, "a"), "b": DataNode(None, "b")})
+    assert isinstance(inlined, DataNode)
+    assert inlined() == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    "inst",
+    [
+        Task("key-1", func, "a", "b"),
+        SequenceOfTasks("key-1", [DataNode(None, "foo")]),
+        DictOfTasks("key-1", {"foo": DataNode(None, "foo")}),
+        Alias("key-1"),
+        DataNode("key-1", 1),
+    ],
+)
+def test_ensure_slots(inst):
+    assert not hasattr(inst, "__dict__")
+
+
+class PlainNamedTuple(namedtuple("PlainNamedTuple", "value")):
+    """Namedtuple with a default constructor."""
+
+
+class NewArgsNamedTuple(namedtuple("NewArgsNamedTuple", "ab, c")):
+    """Namedtuple with a custom constructor."""
+
+    def __new__(cls, a, b, c):
+        return super().__new__(cls, f"{a}-{b}", c)
+
+    def __getnewargs__(self):
+        return *self.ab.split("-"), self.c
+
+
+class NewArgsExNamedTuple(namedtuple("NewArgsExNamedTuple", "ab, c, k, v")):
+    """Namedtuple with a custom constructor including keywords-only arguments."""
+
+    def __new__(cls, a, b, c, **kw):
+        return super().__new__(cls, f"{a}-{b}", c, tuple(kw.keys()), tuple(kw.values()))
+
+    def __getnewargs_ex__(self):
+        return (*self.ab.split("-"), self.c), dict(zip(self.k, self.v))
+
+
+@pytest.mark.parametrize(
+    "typ, args, kwargs",
+    [
+        (PlainNamedTuple, ["some-data"], {}),
+        (NewArgsNamedTuple, ["some", "data", "more"], {}),
+        (NewArgsExNamedTuple, ["some", "data", "more"], {"another": "data"}),
+    ],
+)
+def test_parse_graph_namedtuple_legacy(typ, args, kwargs):
+    def func(x):
+        return x
+
+    dsk = {"foo": (func, typ(*args, **kwargs))}
+    new_dsk = convert_legacy_graph(dsk)
+    _assert_dsk_conversion(new_dsk)
+
+    assert new_dsk["foo"]() == typ(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "typ, args, kwargs",
+    [
+        (PlainNamedTuple, ["some-data"], {}),
+        (NewArgsNamedTuple, ["some", "data", "more"], {}),
+        (NewArgsExNamedTuple, ["some", "data", "more"], {"another": "data"}),
+    ],
+)
+def test_parse_namedtuple(typ, args, kwargs):
+    def func(x):
+        return x
+
+    obj = typ(*args, **kwargs)
+    t = Task("foo", func, obj)
+
+    assert t() == obj
+
+    # The other test tuple do weird things to their input
+    if typ is PlainNamedTuple:
+        args = tuple([TaskRef("b")] + list(args)[1:])
+        obj = typ(*args, **kwargs)
+        t = Task("foo", func, obj)
+        assert t.dependencies == {"b"}
+        assert t({"b": "foo"}) == typ(*tuple(["foo"] + list(args)[1:]), **kwargs)
+
+
+def test_pickle_literals():
+    np = pytest.importorskip("numpy")
+    obj = DataNode("foo", np.transpose)
+    roundtripped = pickle.loads(pickle.dumps(obj))
+    assert roundtripped == obj
+
+
+def test_resolve_aliases():
+    tasks = [
+        Alias("bar", "foo"),
+        Task("foo", func, "a", "b"),
+        Alias("baz", "bar"),
+    ]
+    dsk = {t.key: t for t in tasks}
+    assert len(dsk) == 3
+
+    optimized = resolve_aliases(dsk, {"baz"}, reverse_dict(DependenciesMapping(dsk)))
+    assert len(optimized) == 1
+    expected = dsk["foo"].copy()
+    expected.key = "baz"
+    assert optimized["baz"] == expected
+
+    optimized = resolve_aliases(
+        dsk, {"baz", "bar"}, reverse_dict(DependenciesMapping(dsk))
+    )
+    assert len(optimized) == 2
+    expected = dsk["foo"].copy()
+    expected.key = "bar"
+    assert optimized["bar"] == expected
+
+    tasks = [
+        bar := Alias("bar", "foo"),
+        Task("foo", func, "a", "b"),
+        Alias("baz", bar.ref()),
+        Task("foo2", func, bar.ref(), "c"),
+    ]
+    dsk = {t.key: t for t in tasks}
+    optimized = resolve_aliases(
+        dsk, {"baz", "foo2"}, reverse_dict(DependenciesMapping(dsk))
+    )
+    assert len(optimized) == 3
+    # FIXME: Ideally, the above example would optimize to this but this isn't
+    # implemented. Instead, we'll block to not mess up anything
+    # assert sorted(optimized.values(), key=lambda t: t.key) == sorted(
+    #     [
+    #         Task("baz", func, "a", "b"),
+    #         Task("foo", func, TaskRef("baz"), "c"),
+    #     ],
+    #     key=lambda t: t.key,
+    # )
+    # `bar` won't be inlined because it's used in `foo2` AND `baz`
+    assert "bar" in optimized
+    assert optimized["bar"].key == "bar"
+    assert "foo" not in optimized
+
+    # Handle cases with external dependencies
+    foo = Task("foo", func, "a", TaskRef("b"))
+    dsk = {t.key: t for t in [foo]}
+    optimized = resolve_aliases(dsk, {"foo"}, reverse_dict(DependenciesMapping(dsk)))
+    assert optimized == dsk
+
+
+def test_parse_nested():
+    t = Task(
+        "key",
+        func3,
+        x=TaskRef("y"),
+    )
+
+    assert t({"y": "y"}) == "//x=y"
+
+
+class CountSerialization:
+    serialization = 0
+    deserialization = 0
+
+    def __getstate__(self):
+        CountSerialization.serialization += 1
+        return "foo"
+
+    def __setstate__(self, state):
+        CountSerialization.deserialization += 1
+        pass
+
+    def __call__(self):
+        return 1
+
+
+def test_no_function_cache():
+    func = CountSerialization()
+    t = Task("k", func)
+    assert t() == 1
+    assert CountSerialization.serialization == 0
+    assert CountSerialization.deserialization == 0
+    t.pack()
+    assert CountSerialization.serialization == 1
+    assert CountSerialization.deserialization == 0
+    # use cache already
+    t.unpack()
+    assert CountSerialization.serialization == 1
+    assert CountSerialization.deserialization == 0
+    t.pack().unpack().pack().unpack()
+    assert CountSerialization.serialization == 1
+    assert CountSerialization.deserialization == 0
+
+    with no_function_cache():
+        t.pack()
+        assert CountSerialization.serialization == 2
+        assert CountSerialization.deserialization == 0
+        t.unpack()
+        assert CountSerialization.serialization == 2
+        assert CountSerialization.deserialization == 1
+
+    # We'll use a new task object since the above no-cache rountrip replaced the
+    # func instance such that the pack will cache miss on the first attempt. If
+    # we use the same instance, we'll be fine
+    t = Task("k", func)
+    # The old cache is restored
+    t.pack().unpack().pack().unpack()
+    assert CountSerialization.serialization == 2
+    assert CountSerialization.deserialization == 1
+
+
+class RaiseOnSerialization:
+    def __getstate__(self):
+        raise ValueError("Nope")
+
+    def __call__(self):
+        return 1
+
+
+class RaiseOnDeSerialization:
+    def __getstate__(self):
+        return "Nope"
+
+    def __setstate__(self, state):
+        raise ValueError(state)
+
+    def __call__(self):
+        return 1
+
+
+def test_raise_runtimeerror_deserialization():
+    with no_function_cache():
+        t = Task("key", RaiseOnSerialization())
+        assert t() == 1
+        with pytest.raises(RuntimeError, match="key"):
+            t.pack()
+
+        t = Task("key", RaiseOnDeSerialization())
+        assert t() == 1
+        t.pack()
+        with pytest.raises(RuntimeError, match="key"):
+            t.unpack()
+
+
+# This is duplicated from distributed/utils_test.py
+def _get_gc_overhead():
+    class _CustomObject:
+        def __sizeof__(self):
+            return 0
+
+    return sys.getsizeof(_CustomObject())
+
+
+_size_obj = _get_gc_overhead()
+
+
+class SizeOf:
+    """
+    An object that returns exactly nbytes when inspected by dask.sizeof.sizeof
+    """
+
+    def __init__(self, nbytes: int) -> None:
+        if not isinstance(nbytes, int):
+            raise TypeError(f"Expected integer for nbytes but got {type(nbytes)}")
+        if nbytes < _size_obj:
+            raise ValueError(
+                f"Expected a value larger than {_size_obj} integer but got {nbytes}."
+            )
+        self._nbytes = nbytes - _size_obj
+
+    def __sizeof__(self) -> int:
+        return self._nbytes
+
+
+def test_sizeof():
+    t = Task("key", func, "a", "b")
+    assert sizeof(t) > sizeof(Task) + sizeof(list) + 2 * sizeof("a")
+
+    t = Task("key", func, SizeOf(100_000))
+    assert sizeof(t) > 100_000
+    t = DataNode("key", SizeOf(100_000))
+    assert sizeof(t) > 100_000

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 import pytest
 
 import dask
-from dask._task_spec import (  # DictOfTasks,; SequenceOfTasks,
+from dask._task_spec import (
     Alias,
     DataNode,
     DependenciesMapping,
@@ -15,6 +15,7 @@ from dask._task_spec import (  # DictOfTasks,; SequenceOfTasks,
     TaskRef,
     convert_legacy_graph,
     convert_legacy_task,
+    execute_graph,
     no_function_cache,
     resolve_aliases,
 )
@@ -359,7 +360,7 @@ def test_subgraph_callable():
         "c": (subgraph, "a", "b"),
     }
     new_dsk = convert_legacy_graph(dsk)
-    # _assert_dsk_conversion(new_dsk)
+    _assert_dsk_conversion(new_dsk)
     assert new_dsk["c"].dependencies == {"a", "b", "add-123"}
     assert (
         new_dsk["c"](
@@ -711,9 +712,6 @@ def test_sizeof():
     assert sizeof(t) > 100_000
     t = DataNode("key", SizeOf(100_000))
     assert sizeof(t) > 100_000
-
-
-from dask._task_spec import execute_graph
 
 
 def test_execute_tasks_in_graph():

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -7,15 +7,14 @@ from collections import namedtuple
 import pytest
 
 import dask
-from dask._task_spec import (
+from dask._task_spec import (  # DictOfTasks,; SequenceOfTasks,
     Alias,
     DataNode,
     DependenciesMapping,
-    DictOfTasks,
-    SequenceOfTasks,
     Task,
     TaskRef,
     convert_legacy_graph,
+    convert_legacy_task,
     no_function_cache,
     resolve_aliases,
 )
@@ -31,6 +30,10 @@ def clear_func_cache():
 
     _func_cache.clear()
     _func_cache_reverse.clear()
+
+
+def identity(x):
+    return x
 
 
 def func(*args):
@@ -100,7 +103,7 @@ def test_convert_legacy_dsk():
     v3 = t3({"key-1": v1, "key-2": v2})
     assert v3 == func(func2("c", func("a", "b")), func2(func("a", "b"), "c"))
     t4 = new_dsk["key-4"]
-    assert isinstance(t4, SequenceOfTasks)
+    assert isinstance(t4, Task)
     assert t4.dependencies == {"key-1", "key-2", "key-3", "const"}
     assert t4(
         {
@@ -120,6 +123,20 @@ def test_convert_legacy_dsk():
 def test_task_executable():
     t1 = Task("key-1", func, "a", "b")
     assert t1() == func("a", "b")
+
+
+def test_task_nested_sequence():
+    t1 = Task("key-1", func, "a", "b")
+    t2 = Task("key-2", func2, "c", "d")
+
+    tseq = Task("seq", identity, [t1, t2])
+    assert tseq() == [func("a", "b"), func2("c", "d")]
+
+    tseq = Task("set", identity, {t1, t2})
+    assert tseq() == {func("a", "b"), func2("c", "d")}
+
+    tseq = Task("dict", identity, {"a": t1, "b": t2})
+    assert tseq() == {"a": func("a", "b"), "b": func2("c", "d")}
 
 
 def test_reference_remote():
@@ -272,6 +289,14 @@ def test_avoid_cycles():
     assert not new_dsk
 
 
+def test_convert_tasks_only_ref_lowlevel():
+    t = convert_legacy_task(None, (func, "a", "b"), set(), only_refs=True)
+    assert t() == (func, "a", "b")
+
+    t = convert_legacy_task(None, (func, "a", "b"), {"a"}, only_refs=True)
+    assert t({"a": "c"}) == (func, "c", "b")
+
+
 def test_convert_task_only_ref():
     # This is for support of legacy subgraphs
     # We'll only want to insert pack/unpack dependencies but don't want to touch
@@ -334,7 +359,7 @@ def test_subgraph_callable():
         "c": (subgraph, "a", "b"),
     }
     new_dsk = convert_legacy_graph(dsk)
-    _assert_dsk_conversion(new_dsk)
+    # _assert_dsk_conversion(new_dsk)
     assert new_dsk["c"].dependencies == {"a", "b", "add-123"}
     assert (
         new_dsk["c"](
@@ -390,14 +415,14 @@ def test_inline():
 
     assert inline2({"b": "foo"}) == "a-foo"
 
-    t = SequenceOfTasks("key-1", [t, t2])
+    t = Task("foo", identity, [t, t2])
     assert t.dependencies == {"b", "a"}
     inlined = t.inline({"a": DataNode(None, "foo")})
     assert inlined.dependencies == {"b"}
     assert inlined({"b": "bar"}) == ["a-bar", "foo-bar"]
 
-    t = SequenceOfTasks("key-2", [t, t2])
-    t = DictOfTasks("key-2", {"foo": t, "bar": t2})
+    t = Task("key-2", identity, [t, t2])
+    t = Task("key-2", identity, {"foo": t, "bar": t2})
     inlined = t.inline(
         {
             "a": DataNode(None, "foo"),
@@ -406,9 +431,8 @@ def test_inline():
     )
     assert inlined({"b": "bar"})
 
-    t = SequenceOfTasks("key-1", [TaskRef("a"), TaskRef("b")])
+    t = Task("key-1", identity, [TaskRef("a"), TaskRef("b")])
     inlined = t.inline({"a": DataNode(None, "a"), "b": DataNode(None, "b")})
-    assert isinstance(inlined, DataNode)
     assert inlined() == ["a", "b"]
 
 
@@ -416,8 +440,6 @@ def test_inline():
     "inst",
     [
         Task("key-1", func, "a", "b"),
-        SequenceOfTasks("key-1", [DataNode(None, "foo")]),
-        DictOfTasks("key-1", {"foo": DataNode(None, "foo")}),
         Alias("key-1"),
         DataNode("key-1", 1),
     ],
@@ -689,3 +711,18 @@ def test_sizeof():
     assert sizeof(t) > 100_000
     t = DataNode("key", SizeOf(100_000))
     assert sizeof(t) > 100_000
+
+
+from dask._task_spec import execute_graph
+
+
+def test_execute_tasks_in_graph():
+    dsk = [
+        t1 := Task("key-1", func, "a", "b"),
+        t2 := Task("key-2", func2, t1.ref(), "c"),
+        t3 := Task("key-3", func, "foo", "bar"),
+        Task("key-4", func, t3.ref(), t2.ref()),
+    ]
+    res = execute_graph(dsk)
+    assert len(res) == 1
+    assert res["key-4"] == "foo-bar-a-b=c"

--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -877,10 +877,6 @@ def test_tokenize_dict_doesnt_call_str_on_values():
 
 
 def test_tokenize_sorts_dict_before_seen_map():
-    """When sequence values are repeated, the 2nd+ entry is tokenized as (__seen, 0).
-    This makes it important to ensure that dicts are sorted *before* you call
-    normalize_token() on their elements.
-    """
     v = (1, 2, 3)
     d1 = {1: v, 2: v}
     d2 = {2: v, 1: v}
@@ -888,11 +884,6 @@ def test_tokenize_sorts_dict_before_seen_map():
 
 
 def test_tokenize_sorts_set_before_seen_map():
-    """Same as test_tokenize_sorts_dict_before_seen_map, but for sets.
-
-    Note that this test is only meaningful if set insertion order impacts iteration
-    order, which is an implementation detail of the Python interpreter.
-    """
     v = (1, 2, 3)
     s1 = {(i, v) for i in range(100)}
     s2 = {(i, v) for i in reversed(range(100))}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,10 +1,56 @@
 Changelog
 =========
 
+.. _v2024.9.0:
+
+2024.9.0
+--------
+
+Highlights
+^^^^^^^^^^
+
+Bump Bokeh minimum version to 3.1.0
+"""""""""""""""""""""""""""""""""""
+``bokeh>=3.1.0`` is now required for diagnostics and the distributed cluster dashboard.
+
+See :pr:`11375` and :pr-distributed:`8861` by `James Bourbeau`_ for more details.
+
+Introduce new Task class
+""""""""""""""""""""""""
+Add a ``Task`` class to replace tuples for task specification.
+
+See :pr:`11248` by `Florian Jetter`_ for more details.
+
+.. dropdown:: Additional changes
+
+  - Bump ``peter-evans/create-pull-request`` from 6 to 7 (:pr:`11380`)
+  - Reduce overhead in tokenize (:pr:`11373`) `Florian Jetter`_
+  - Move ``tokenize`` to dedicated submodule (:pr:`11371`) `Florian Jetter`_
+  - Ensure ``process_runnables`` is not too eager in the presence of multiple splits (:pr:`11367`) `Florian Jetter`_
+  - Use ``np.min_scalar_type`` in shuffle (:pr:`11369`) `James Bourbeau`_
+  - Write indexing arrays into dask graph to reduce size for multiple xarray variables (:pr:`11362`) `Patrick Hoefler`_
+  - Cast indexer to minimal ``dtype`` in shuffle (:pr:`11364`) `Patrick Hoefler`_
+  - Reduce memory usage of ``dask.order`` (:pr:`11361`) `Florian Jetter`_
+  - Bump ``JamesIves/github-pages-deploy-action`` from 4.6.3 to 4.6.4 (:pr:`11366`)
+  - ``precommit`` autoupdate (:pr:`11360`) `Florian Jetter`_
+
+  - Homogeneously schedule P2P's unpack tasks (:pr-distributed:`8873`) `Hendrik Makait`_
+  - Work/fix firewall for localhost (:pr-distributed:`8868`) `Mario Linker`_
+  - Use new ``tokenize`` module (:pr-distributed:`8858`) `James Bourbeau`_
+  - Point to user code with idempotent plugin warning (:pr-distributed:`8856`) `James Bourbeau`_
+  - Fix test nanny timeout (:pr-distributed:`8847`) `Florian Jetter`_
+  - Bump JamesIves/github-pages-deploy-action from 4.5.0 to 4.6.4 (:pr-distributed:`8853`)
+  - Speed up ``Client.map`` by computing ``token`` only once for ``func`` and ``kwargs`` (:pr-distributed:`8855`) `Florian Jetter`_
+  - Update ``pre-commit`` (:pr-distributed:`8852`) `Florian Jetter`_
+
+
 .. _v2024.8.2:
 
 2024.8.2
 --------
+
+Highlights
+^^^^^^^^^^
 
 Automatic selection of rechunking method
 """"""""""""""""""""""""""""""""""""""""
@@ -8771,3 +8817,4 @@ Other
 .. _`Lucas Colley`: https://github.com/lucascolley
 .. _`Tao Xin`: https://github.com/Tao-VanJS
 .. _`David Stansby`: https://github.com/dstansby
+.. _`Mario Linker`: https://github.com/maldag

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,6 +1,32 @@
 Changelog
 =========
 
+.. _v2024.9.1:
+
+2024.9.1
+--------
+
+Highlights
+^^^^^^^^^^
+
+Improved adaptive scaling resilience
+""""""""""""""""""""""""""""""""""""
+Adaptive scaling clusters now recover from spurious errors during scaling.
+
+See :pr-distributed:`8871` by `Hendrik Makait`_ for more details.
+  
+.. dropdown:: Additional changes
+
+  - Improve error message for incorrect columns order in meta information (:pr:`11393`) `Dmitry Balabka`_
+  - Update gpuCI ``RAPIDS_VER`` to ``24.12`` (:pr:`11407`)
+  - Bump ``jacobtomlinson/gha-anaconda-package-version`` from 0.1.3 to 0.1.4 (:pr:`11405`)
+  - Switch to using ``zarr.open_array`` instead of using the ``zarr.Array`` constructor (:pr:`11387`) `Joe Hamman`_
+
+  - Update gpuCI ``RAPIDS_VER`` to ``24.12`` (:pr-distributed:`8879`)
+  - Don't consider scheduler idle while executing ``Scheduler.update_graph`` (:pr-distributed:`8877`) `Hendrik Makait`_
+  - Bump ``jacobtomlinson/gha-anaconda-package-version`` from 0.1.3 to 0.1.4 (:pr-distributed:`8878`)
+  - Support P2P rechunking datetime arrays (:pr-distributed:`8875`) `James Bourbeau`_
+
 .. _v2024.9.0:
 
 2024.9.0
@@ -8818,3 +8844,4 @@ Other
 .. _`Tao Xin`: https://github.com/Tao-VanJS
 .. _`David Stansby`: https://github.com/dstansby
 .. _`Mario Linker`: https://github.com/maldag
+.. _`Dmitry Balabka`: https://github.com/dbalabka

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dataframe = [
     "pandas >= 2.0",
     "dask-expr >= 1.1, <1.2",  # dask-expr pins the dask version
 ]
-distributed = ["distributed == 2024.8.2"]
+distributed = ["distributed == 2024.9.0"]
 diagnostics = [
     "bokeh >= 3.1.0",
     "jinja2 >= 2.10.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dataframe = [
     "pandas >= 2.0",
     "dask-expr >= 1.1, <1.2",  # dask-expr pins the dask version
 ]
-distributed = ["distributed == 2024.9.0"]
+distributed = ["distributed == 2024.9.1"]
 diagnostics = [
     "bokeh >= 3.1.0",
     "jinja2 >= 2.10.3",


### PR DESCRIPTION
This commit would remove the sequence and dict classes


It's a bit awkward because I intentionally don't want to implement full recursion on everything we're encountering, i.e. only explicit arguments to a task are considered tasks themselves but we will ignore nested tasks.

Dicts in particular are a little awkward if we ditch the class that handles dicts in a special way. But this logic can be encoded in a function...

cc @hendrikmakait